### PR TITLE
fix: Update license format to SPDX standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Advanced error handling utilities for Python applications"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT"}
+license = "MIT"
 authors = [
     {name = "Avi Layani", email = "alayani@redhat.com"},
 ]
@@ -19,7 +19,6 @@ keywords = ["error", "exception", "handling", "utilities", "decorators", "loggin
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
- Changed license from {text = 'MIT'} to 'MIT' (SPDX identifier)
- Removed deprecated 'License :: OSI Approved :: MIT License' classifier
- Resolves setuptools deprecation warnings during build