### PR TITLE
chore: Add wiki/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ cython_debug/
 # Cursor
 .cursor/
 
+# Wiki (kept as local reference)
+wiki/
+
 # macOS
 .DS_Store
 


### PR DESCRIPTION
## Summary

Small housekeeping update to add the `wiki/` directory to `.gitignore`.

## Rationale

The wiki documentation has been successfully published to GitHub's wiki repository (separate from the main repo). The local `wiki/` directory is kept as a reference but doesn't need to be tracked in the main repository.

## Changes

- Added `wiki/` to `.gitignore` with a comment explaining it's kept as local reference only

This keeps the repository clean while allowing developers to maintain local copies of the wiki documentation for reference.